### PR TITLE
Explicitly set the vehicle spawn delay to 100 while switching maps.

### DIFF
--- a/battlefield_rcon/src/bf4.rs
+++ b/battlefield_rcon/src/bf4.rs
@@ -676,10 +676,21 @@ impl Bf4Client {
             .await
     }
 
+    // TODO(dek): Rename to `set_vehicle_spawn_allowed()` to match the var name.
     pub async fn set_vehicles_spawn_allowed(&self, allowed: bool) -> RconResult<()> {
         self.rcon
             .query(
                 &veca!["vars.vehicleSpawnAllowed", allowed.to_string()],
+                ok_eof,
+                |_| None,
+            )
+            .await
+    }
+
+    pub async fn set_vehicle_spawn_delay(&self, delay: usize) -> RconResult<()> {
+        self.rcon
+            .query(
+                &veca!["vars.vehicleSpawnDelay", format!("{}", delay)],
                 ok_eof,
                 |_| None,
             )

--- a/src/mapmanager.rs
+++ b/src/mapmanager.rs
@@ -378,6 +378,12 @@ pub async fn switch_map_to(
 
     let _ = bf4.set_preset(Preset::Custom).await;
     let _ = bf4.set_vehicles_spawn_allowed(vehicles).await;
+
+    // Force the vehicle spawn delay to the default value, 100.
+    // We do this as a safeguard against previously seen quirks,
+    // where the value would be automatically set to 400.
+    let _ = bf4.set_vehicle_spawn_delay(100).await;
+
     let _  = dbg!(bf4.set_tickets(tickets).await);
     sleep(Duration::from_secs(1)).await;
 
@@ -385,6 +391,7 @@ pub async fn switch_map_to(
 
     sleep(Duration::from_secs(10)).await;
     let _  = dbg!(bf4.set_tickets(std::cmp::max(100, tickets)).await);
+    let _ = bf4.set_vehicle_spawn_delay(100).await;
     let _ = bf4.set_vehicles_spawn_allowed(true).await;
     let _ = bf4.set_preset(Preset::Hardcore).await;
 


### PR DESCRIPTION
The vehicle spawn delay has sometimes been observed to increase on its
own in production when using BattleFox or switching between different
instances of BattleFox. This is impacting player UX; several players
have noticed this during multiple rounds and complained about it.
Setting the value explicitly should hopefully prevent this glitch from
happening.