### PR TITLE
Added option for Bf4Client without login

### DIFF
--- a/battlefield_rcon/src/bf4.rs
+++ b/battlefield_rcon/src/bf4.rs
@@ -64,15 +64,18 @@ pub struct Bf4Client {
 
 
 impl Bf4Client {
-    /// Open a connection to a BF4 server without logging in to it. 
-    /// When not logging in, you only have a restricted access and all commands won't work.
+    /// Open a connection to a BF4 server without logging in to it.
+    /// When not logged in, only very few RCON commands are permitted, such as `serverInfo`.
+    /// Commands such as kill won't work and you'll get an error instead.
     ///
     /// # Examples
     ///
-    /// ```
+    /// ```no_run
     /// use battlefield_rcon::bf4::Bf4Client;
-    ///
+    /// # async fn f() {
     /// let bf4_client = Bf4Client::connect_restricted("127.0.0.1:47200").await.unwrap();
+    /// let info = bf4_client.server_info().await.unwrap();
+    /// # }
     /// ```
     pub async fn connect_restricted(addr: impl ToSocketAddrs) -> RconResult<Arc<Self>> {
         let rcon = RconClient::connect(addr).await?;

--- a/battlefield_rcon/src/bf4.rs
+++ b/battlefield_rcon/src/bf4.rs
@@ -72,7 +72,7 @@ impl Bf4Client {
     /// ```
     /// use battlefield_rcon::bf4::Bf4Client;
     ///
-    /// let bf4_client = Bf4Client::connect_restricted("127.0.0.1:47200",).await.unwrap();
+    /// let bf4_client = Bf4Client::connect_restricted("127.0.0.1:47200").await.unwrap();
     /// ```
     pub async fn connect_restricted(addr: impl ToSocketAddrs) -> RconResult<Arc<Self>> {
         let rcon = RconClient::connect(addr).await?;

--- a/battlefield_rcon/src/bf4.rs
+++ b/battlefield_rcon/src/bf4.rs
@@ -64,6 +64,21 @@ pub struct Bf4Client {
 
 
 impl Bf4Client {
+    /// Open a connection to a BF4 server without logging in to it. 
+    /// When not logging in, you only have a restricted access and all commands won't work.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use battlefield_rcon::bf4::Bf4Client;
+    ///
+    /// let bf4_client = Bf4Client::connect_restricted("127.0.0.1:47200",).await.unwrap();
+    /// ```
+    pub async fn connect_restricted(addr: impl ToSocketAddrs) -> RconResult<Arc<Self>> {
+        let rcon = RconClient::connect(addr).await?;
+        Bf4Client::new_from(rcon).await
+    }
+
     pub async fn connect(addr: impl ToSocketAddrs, password: AsciiString) -> RconResult<Arc<Self>> {
         let rcon = RconClient::connect(addr).await?;
         rcon.login_hashed(password).await?;

--- a/battlefield_rcon/src/lib.rs
+++ b/battlefield_rcon/src/lib.rs
@@ -38,3 +38,30 @@ pub mod macros;
 #[cfg(feature = "bf4")]
 pub mod bf4;
 pub mod rcon;
+
+#[cfg(test)]
+mod tests {
+    use crate::bf4::{Bf4Client, ServerInfoError};
+
+    #[tokio::test]
+    async fn test_server_info() {
+        let bf4 = Bf4Client::connect_restricted(
+            "127.0.0.1:47200",
+        )
+        .await
+        .unwrap();
+    
+        // Server info test
+        let serverinfo = match bf4.server_info().await {
+            Ok(info) => info,
+            Err(ServerInfoError::Rcon(rconerr)) => panic!("{:?}", rconerr),
+        };
+
+        // println!("ServerInfo {:?}", serverinfo);
+
+        let json_string = serde_json::to_string(&serverinfo).unwrap();
+        println!("{}", json_string);
+
+        assert_eq!("IN_GAME", serverinfo.blaze_game_state);
+    }
+}

--- a/battlefield_rcon/src/lib.rs
+++ b/battlefield_rcon/src/lib.rs
@@ -44,6 +44,7 @@ mod tests {
     use crate::bf4::{Bf4Client, ServerInfoError};
 
     #[tokio::test]
+    #[ignore]
     async fn test_server_info() {
         let bf4 = Bf4Client::connect_restricted(
             "127.0.0.1:47200",

--- a/battlefield_rcon/src/lib.rs
+++ b/battlefield_rcon/src/lib.rs
@@ -51,7 +51,7 @@ mod tests {
         )
         .await
         .unwrap();
-    
+
         // Server info test
         let serverinfo = match bf4.server_info().await {
             Ok(info) => info,


### PR DESCRIPTION
Added option for Bf4Client connect without login so it can be used for commands that don't require login when you don't know the server password.